### PR TITLE
[SALT-18] Fix: 링크 편집기능 활성화 시 노드 리사이징을 할 수 없도록 구현함

### DIFF
--- a/src/components/ProjectPage/Buttons/AddButton.css
+++ b/src/components/ProjectPage/Buttons/AddButton.css
@@ -1,0 +1,4 @@
+.add-button-wrapper.disabled {
+  opacity: 0.5; 
+  pointer-events: none;
+}

--- a/src/components/ProjectPage/Buttons/AddButton.jsx
+++ b/src/components/ProjectPage/Buttons/AddButton.jsx
@@ -1,20 +1,30 @@
-import React from "react";
-import "./Buttons.css";
-import AddIcon from "../../../assets/images/add-icon.png";
-import ObjectIcon from "../../../assets/images/object-icon2.png";
-import LinkIcon from "../../../assets/images/link-icon2.png";
+import React from 'react';
+import './Buttons.css';
+import AddIcon from '../../../assets/images/add-icon.png';
+import ObjectIcon from '../../../assets/images/object-icon2.png';
+import LinkIcon from '../../../assets/images/link-icon2.png';
+import './AddButton.css';
 
 const images = {
-  "add-icon.png": AddIcon,
-  "object-icon.png": ObjectIcon,
-  "link-icon.png": LinkIcon,
+  'add-icon.png': AddIcon,
+  'object-icon.png': ObjectIcon,
+  'link-icon.png': LinkIcon,
 };
 
-export const AddButton = ({ fileName, onClickEvent, needCancel }) => {
+export const AddButton = ({ fileName, onClickEvent, needCancel, disabled }) => {
+  const handleClick = (e) => {
+    if (!disabled) {
+      onClickEvent(e);
+    }
+  };
+
   return (
-    <div className="add-button-wrapper" onClick={onClickEvent}>
+    <div
+      className={`add-button-wrapper ${disabled ? 'disabled' : ''}`}
+      onClick={handleClick}
+    >
       <div
-        className={`add-button-content-container ${needCancel ? "cancel" : ""}`}
+        className={`add-button-content-container ${needCancel ? 'cancel' : ''}`}
       >
         <img
           src={images[fileName]}
@@ -23,12 +33,12 @@ export const AddButton = ({ fileName, onClickEvent, needCancel }) => {
         />
       </div>
       <div
-        className={`add-button-symbol-container ${needCancel ? "cancel" : ""}`}
+        className={`add-button-symbol-container ${needCancel ? 'cancel' : ''}`}
       >
         <img
           src={AddIcon}
           alt="더하기 기호"
-          className={`add-button-symbol ${needCancel ? "rotate" : ""}`}
+          className={`add-button-symbol ${needCancel ? 'rotate' : ''}`}
         />
       </div>
     </div>

--- a/src/components/ProjectPage/NetworkMap.jsx
+++ b/src/components/ProjectPage/NetworkMap.jsx
@@ -1,19 +1,19 @@
-import ReactDOMServer from "react-dom/server";
-import cytoscape from "cytoscape";
-import dagre from "cytoscape-dagre";
-import nodeHtmlLabel from "cytoscape-node-html-label";
-import edgehandles from "cytoscape-edgehandles";
-import EHoptions from "../../constants/EdgeHandleOptions";
-import nodeEditing from "cytoscape-node-editing";
-import jQuery from "jquery";
-import konva from "konva";
+import ReactDOMServer from 'react-dom/server';
+import cytoscape from 'cytoscape';
+import dagre from 'cytoscape-dagre';
+import nodeHtmlLabel from 'cytoscape-node-html-label';
+import edgehandles from 'cytoscape-edgehandles';
+import EHoptions from '../../constants/EdgeHandleOptions';
+import nodeEditing from 'cytoscape-node-editing';
+import jQuery from 'jquery';
+import konva from 'konva';
 
-import { useContext, useEffect, useRef } from "react";
-import { NetworkContext } from "../../contexts/NetworkContext";
-import { CustomDeviceNode } from "./CustomDeviceNode";
-import { ToolBox } from "./ToolBox";
-import { Modal } from "./Modals/Modal";
-import { BackgroundNode } from "./BackgroundNode";
+import { useContext, useEffect, useRef } from 'react';
+import { NetworkContext } from '../../contexts/NetworkContext';
+import { CustomDeviceNode } from './CustomDeviceNode';
+import { ToolBox } from './ToolBox';
+import { Modal } from './Modals/Modal';
+import { BackgroundNode } from './BackgroundNode';
 
 cytoscape.use(dagre);
 cytoscape.use(edgehandles);
@@ -21,34 +21,44 @@ nodeHtmlLabel(cytoscape);
 nodeEditing(cytoscape, jQuery, konva);
 
 export const NetworkMap = () => {
-  const { cyRef, nodes,setNodes, edges, isLinking, isModalOpen } =
-    useContext(NetworkContext);
+  const {
+    cyRef,
+    nodes,
+    setNodes,
+    edges,
+    isLinking,
+    setIsLinking,
+    isModalOpen,
+    isResizable,
+
+    setisResizable,
+  } = useContext(NetworkContext);
   useEffect(() => {
     const cy = cytoscape({
-      container: document.getElementById("cy"),
+      container: document.getElementById('cy'),
       // 노드 스타일 : elements의 크기를 반영하는데 필요
       style: [
         {
-          selector: ".device[width][height]",
+          selector: '.device[width][height]',
           style: {
-            label: "data(id)",
-            "background-opacity": 0,
-            width: "data(width)",
-            height: "data(height)",
+            label: 'data(id)',
+            'background-opacity': 0,
+            width: 'data(width)',
+            height: 'data(height)',
           },
         },
         {
-          selector: ".device[width][height]:selected",
+          selector: '.device[width][height]:selected',
           style: {
-            label: "data(id)",
-            "background-opacity": 0,
-            width: "data(width)",
-            height: "data(height)",
+            label: 'data(id)',
+            'background-opacity': 0,
+            width: 'data(width)',
+            height: 'data(height)',
           },
         },
       ],
       layout: {
-        name: "dagre",
+        name: 'dagre',
         padding: 24,
         spacingFactor: 1.5,
       },
@@ -60,28 +70,28 @@ export const NetworkMap = () => {
 
     cy.nodeHtmlLabel([
       {
-        query: "#background",
-        halign: "center",
-        valign: "center",
-        halignBox: "center",
-        valignBox: "center",
-        cssClass: "",
+        query: '#background',
+        halign: 'center',
+        valign: 'center',
+        halignBox: 'center',
+        valignBox: 'center',
+        cssClass: '',
         tpl(data) {
           return `${ReactDOMServer.renderToString(
-            <BackgroundNode data={data} />
+            <BackgroundNode data={data} />,
           )}`;
         },
       },
       {
-        query: ".device",
-        halign: "center",
-        valign: "center",
-        halignBox: "center",
-        valignBox: "center",
-        cssClass: "",
+        query: '.device',
+        halign: 'center',
+        valign: 'center',
+        halignBox: 'center',
+        valignBox: 'center',
+        cssClass: '',
         tpl(data) {
           return `${ReactDOMServer.renderToString(
-            <CustomDeviceNode node={cy.getElementById(data.id)} data={data} />
+            <CustomDeviceNode node={cy.getElementById(data.id)} data={data} />,
           )}`;
         },
       },
@@ -91,25 +101,21 @@ export const NetworkMap = () => {
       padding: 5,
       undoable: true,
       grappleSize: 6,
-      grappleColor: "#fff",
-      grappleStrokeColor: "#666666",
+      grappleColor: '#fff',
+      grappleStrokeColor: '#666666',
       grappleStrokeWidth: 1,
-      inactiveGrappleStroke: "inside 1px",
+      inactiveGrappleStroke: 'inside 1px',
       boundingRectangleLineDash: [2, 4],
-      boundingRectangleLineColor: "#666666",
-
-      isFixedAspectRatioResizeMode: function (node) {
-        return node.is(".fixedAspectRatioResizeMode");
-      },
+      boundingRectangleLineColor: '#666666',
     });
 
     // 노드 리사이징을 하고 나면 state에 width와 height를 반영
-    cy.on("nodeediting.resizeend", function (event, type, node) {
+    cy.on('nodeediting.resizeend', function (event, type, node) {
       const width = node.width();
       const height = node.height();
 
-      node.data("width", width);
-      node.data("height", height);
+      node.data('width', width);
+      node.data('height', height);
 
       cy.elements().forEach((ele) => {
         console.log(ele.data());
@@ -131,34 +137,52 @@ export const NetworkMap = () => {
       cy.elements().remove();
       cy.add([...nodes, ...edges]);
       cy.layout({
-        name: "dagre",
+        name: 'dagre',
         padding: 24,
         spacingFactor: 1.5,
       }).run();
     }
   }, [nodes]);
+
   useEffect(() => {
     const cy = cyRef.current;
     const eh = cy.edgehandles(EHoptions);
 
+    cy.elements().unselect(); // 링크 편집상태를 바꾸면 모든 노드 선택 초기화
+
     if (isLinking) {
       eh.enableDrawMode();
-
-      cy.on("ehstart", (event, sourceNode) => {
-        if (sourceNode.id() === "background") {
+      setisResizable(false);
+      // 링크 편집을 활성화할 경우 디바이스 노드에 noResizeMode추가
+      // 아이콘 노드의 경우는 리사이징을 불가능하게 설계해서 device 노드에만 noResizeMode를 핸들링함
+      // 차후 text노드에 대해서도 구현 예정
+      cy.on('ehstart', (event, sourceNode) => {
+        if (sourceNode.id() === 'background') {
           eh.stop();
         }
       });
     } else {
       eh.disableDrawMode();
-      cy.off("ehstart");
+      setisResizable(true);
+
+      cy.off('ehstart');
     }
 
     return () => {
       eh.disableDrawMode();
-      cy.off("ehstart");
+      cy.off('ehstart');
     };
   }, [isLinking]);
+
+  useEffect(() => {
+    const cy = cyRef.current;
+
+    if (isResizable) {
+      cy.nodes('.device').removeClass('noResizeMode');
+    } else {
+      cy.nodes('.device').addClass('noResizeMode');
+    }
+  }, [isResizable]);
 
   const infoButtonOnClick = () => {
     // 노드 정보 가져오기
@@ -181,21 +205,29 @@ export const NetworkMap = () => {
     });
 
     // 콘솔에 정보 출력
-    console.log("노드 정보:", nodesInfo);
-    console.log("엣지 정보:", edgesInfo);
+    console.log('노드 정보:', nodesInfo);
+    console.log('엣지 정보:', edgesInfo);
+    console.log;
+  };
+
+  const converIsLinkingState = () => {
+    setIsLinking((prevState) => !prevState); // 링크 편집 모드활성화 여부를 조작하는 버튼에 연결된 함수
   };
 
   return (
     <>
       <button onClick={infoButtonOnClick}>정보 출력</button>
+      <button onClick={converIsLinkingState}>
+        {isLinking ? '링크 편집 모드 비활성화' : '링크 편집 모드 활성화'}
+      </button>
       {isModalOpen && <Modal />}
       <ToolBox />
       <div
         id="cy"
         style={{
-          width: "800px",
-          height: "600px",
-          border: "1px solid lightgray",
+          width: '800px',
+          height: '600px',
+          border: '1px solid lightgray',
         }}
       />
     </>

--- a/src/components/ProjectPage/ToolBox.jsx
+++ b/src/components/ProjectPage/ToolBox.jsx
@@ -1,14 +1,14 @@
-import React, { useContext, useRef } from "react";
-import { AddButton } from "./Buttons/AddButton";
-import "./ToolBox.css";
-import { NetworkContext } from "../../contexts/NetworkContext";
+import React, { useContext, useRef } from 'react';
+import { AddButton } from './Buttons/AddButton';
+import './ToolBox.css';
+import { NetworkContext } from '../../contexts/NetworkContext';
 
 export const ToolBox = () => {
   const { isLinking, setIsLinking, setIsModalOpen, setCurModalType } =
     useContext(NetworkContext);
   const toggleAddNode = () => {
     setIsModalOpen(true);
-    setCurModalType("create");
+    setCurModalType('create');
   };
   const activeAddLink = () => {
     setIsLinking(true);
@@ -18,15 +18,24 @@ export const ToolBox = () => {
   };
   return (
     <div className="tool-box-container">
-      <AddButton fileName={"object-icon.png"} onClickEvent={toggleAddNode} />
+      <AddButton
+        fileName={'object-icon.png'}
+        onClickEvent={toggleAddNode}
+        disabled={isLinking}
+      />
       {isLinking ? (
         <AddButton
-          fileName={"link-icon.png"}
+          fileName={'link-icon.png'}
           onClickEvent={inactiveAddLink}
           needCancel={true}
+          disabled={false}
         />
       ) : (
-        <AddButton fileName={"link-icon.png"} onClickEvent={activeAddLink} />
+        <AddButton
+          fileName={'link-icon.png'}
+          onClickEvent={activeAddLink}
+          disabled={false}
+        />
       )}
     </div>
   );

--- a/src/contexts/NetworkContext.jsx
+++ b/src/contexts/NetworkContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useEffect, useRef } from "react";
+import React, { createContext, useState, useEffect, useRef } from 'react';
 
 export const NetworkContext = createContext();
 
@@ -6,59 +6,60 @@ export function NetworkProvider({ children }) {
   const cyRef = useRef(null);
   const [nodes, setNodes] = useState([
     {
-      group: "nodes",
-      data: { id: "background", src: null },
+      group: 'nodes',
+      data: { id: 'background', src: null },
       position: { x: 400, y: 300 }, // 캔버스의 중앙 위치 (적절히 조정 가능)
       locked: true,
     },
     {
-      group: "nodes",
-      data: { id: "other", deviceType: "UPS" },
-      classes: "object device",
+      group: 'nodes',
+      data: { id: 'other', deviceType: 'UPS' },
+      classes: 'object device',
     },
     {
-      group: "nodes",
-      data: { id: "parent", label: "parent" },
-      classes: "group",
+      group: 'nodes',
+      data: { id: 'parent', label: 'parent' },
+      classes: 'group',
     },
     {
-      group: "nodes",
+      group: 'nodes',
       data: {
-        id: "child1",
-        parent: "parent",
-        deviceType: "Server",
+        id: 'child1',
+        parent: 'parent',
+        deviceType: 'Server',
       },
       width: 100,
       height: 100,
-      classes: "object device fixedAspectRatioResizeMode", // 가로세로비율 1대1로 리사이징하기 위한 클래스 적용
+      classes: 'object device fixedAspectRatioResizeMode', // 가로세로비율 1대1로 리사이징하기 위한 클래스 적용
     }, // 자식 노드 1
     {
-      group: "nodes",
+      group: 'nodes',
       data: {
-        id: "child2",
-        parent: "parent",
-        deviceType: "Network",
+        id: 'child2',
+        parent: 'parent',
+        deviceType: 'Network',
       },
       width: 100,
       height: 100,
-      classes: "object device fixedAspectRatioResizeMode", // 가로세로비율 1대1로 리사이징하기 위한 클래스 적용
+      classes: 'object device fixedAspectRatioResizeMode', // 가로세로비율 1대1로 리사이징하기 위한 클래스 적용
       grabbable: true,
     },
   ]);
   const [edges, setEdges] = useState([
     {
-      group: "edges",
+      group: 'edges',
       data: {
-        id: "edge1",
-        source: "child1",
-        target: "child2",
+        id: 'edge1',
+        source: 'child1',
+        target: 'child2',
       },
-      classes: "edge",
+      classes: 'edge',
     },
   ]);
   const [isLinking, setIsLinking] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [curModalType, setCurModalType] = useState("");
+  const [curModalType, setCurModalType] = useState('');
+  const [isResizable, setisResizable] = useState(true);
 
   return (
     <NetworkContext.Provider
@@ -74,6 +75,8 @@ export function NetworkProvider({ children }) {
         setIsModalOpen,
         curModalType,
         setCurModalType,
+        isResizable,
+        setisResizable,
       }}
     >
       {children}

--- a/src/pages/ProjectPage.jsx
+++ b/src/pages/ProjectPage.jsx
@@ -1,7 +1,7 @@
-import React from "react";
-import { NetworkMap } from "../components/ProjectPage/NetworkMap";
-import { NetworkProvider } from "../contexts/NetworkContext";
-import "./ProjectPage.css";
+import React from 'react';
+import { NetworkMap } from '../components/ProjectPage/NetworkMap';
+import { NetworkProvider } from '../contexts/NetworkContext';
+import './ProjectPage.css';
 const ProjectPage = () => {
   return (
     <>


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #18

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- [x] 링크 편집기능 활성화 시 노드 리사이징 할 수 없도록 구현
- [x] 링크 편집기능 활성화 시 노드 추가 버튼 비활성화

### 스크린샷 (선택)

## 💬리뷰 요구사항/고민사항(선택)
